### PR TITLE
Remove confusing entries and add additional info

### DIFF
--- a/guides/languages.md
+++ b/guides/languages.md
@@ -32,10 +32,9 @@ branch.
 - SPSS (legacy)
  
 ## Platform Management
-- Powershell (for DevOps / orchestration)
-- CLI
+- Powershell
+- Bash
 - ARM
-- Bat files
  
 ## Business Intelligence Tools
 - PowerBI
@@ -46,6 +45,7 @@ branch.
 - XLST
 - JSON
 - XML (legacy)
+- YAML
  
 ## Other
 Not necessarily programming languages but worth a notable mention


### PR DESCRIPTION
* Removed the description for PowerShell as it was misleading
* Removed CLI because it is unclear what it is referring to
* Removed BAT file. A Bat file isn't a language and we should also be guiding people away from using this them

* Added YAML to Declarative
* Added Bash to Platform Management

We also mention tooling in this article which I feel is out of scope as they are not languages.