### PR TITLE
Downsize paas memory and disk requirements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,4 +38,4 @@ jobs:
         cf api https://api.london.cloud.service.gov.uk
         cf auth
         cf target -o dfe -s technical-architecture
-        cf push -p build -b staticfile_buildpack dfe-technical-guidance
+        cf push -p build -b staticfile_buildpack --disk 128M --memory 64M dfe-technical-guidance


### PR DESCRIPTION
We can reduce the cost by reducing memory and disk requirements (currently 1G each)

After deploy:
```
% cf app dfe-technical-guidance
Showing health and status for app dfe-technical-guidance in org dfe / space technical-architecture as 116032152152065013267...

name:              dfe-technical-guidance
requested state:   started
routes:            dfe-technical-guidance.london.cloudapps.digital, technical-guidance.education.gov.uk
last uploaded:     Thu 22 Apr 17:02:27 BST 2021
stack:             cflinuxfs3
buildpacks:        
	name                   version   detect output   buildpack name
	staticfile_buildpack   1.5.15    staticfile      staticfile

type:           web
sidecars:       
instances:      1/1
memory usage:   64M
     state     since                  cpu    memory        disk           details
#0   running   2021-04-22T16:02:37Z   0.1%   9.1M of 64M   8.2M of 128M   
```