### PR TITLE
Refactor with standard multipage tech docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 
 # Include the tech docs gem
 gem 'govuk_tech_docs'
+
+# HTML-proofer to check links
+gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    ethon (0.14.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
@@ -66,6 +68,14 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (3.6.0)
+    html-proofer (3.19.1)
+      addressable (~> 2.3)
+      mercenary (~> 0.3)
+      nokogumbo (~> 2.0)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -75,6 +85,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.2)
+    mercenary (0.4.0)
     method_source (1.0.0)
     middleman (4.3.11)
       coffee-script (~> 2.2)
@@ -133,6 +144,8 @@ GEM
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogumbo (2.0.5)
+      nokogiri (~> 1.8, >= 1.8.4)
     openapi3_parser (0.5.2)
       commonmarker (~> 0.17)
     padrino-helpers (0.13.3.4)
@@ -150,6 +163,7 @@ GEM
     rack (2.2.3)
     rack-livereload (0.3.17)
       rack
+    rainbow (3.0.0)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -169,16 +183,20 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    typhoeus (1.4.0)
+      ethon (>= 0.9.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    yell (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   govuk_tech_docs
+  html-proofer
   tzinfo-data
   wdm (~> 0.1.0)
 

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,7 @@ server:
 
 .PHONY: build
 build:
-	bundle exec middleman build --verbose
+	rm -rf build && bundle exec middleman build --verbose
+
+check-links:
+	bundle exec ruby -rhtml-proofer -e "HTMLProofer.check_directory('./build').run"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 server:
-	bundle exec middleman server
+	bundle exec middleman server --verbose
 
 .PHONY: build
 build:

--- a/README.md
+++ b/README.md
@@ -28,17 +28,11 @@ This will install all required dependencies, including the [govuk-tech-docs gem]
 
 ## Making documentation changes
 
-To make changes edit the source files in the `source` folder.
-
-Although a single page of HTML is generated the markdown is spread across
-multiple files to make it easier to manage. They can be found in
-`source/documentation`.
-
-Make sure to make changes in a branch, and issue a pull request when you want them to be reviewed and published.
+To make changes edit the source files in the `source` folder. See "Adding a new guidance" page for details.
 
 ## Previewing
 
-Whilst writing documentation we can run a middleman server to preview how the
+Whilst writing documentation, run a middleman server to preview how the
 published version will look in the browser. After saving a change the preview in
 the browser will automatically refresh.
 
@@ -74,9 +68,18 @@ make build
 This will create a `build` subfolder in the application folder which contains
 the HTML and asset files ready to be published.
 
+## Check links
+
+To check all hypertext links inside the generated documentation are valid, build first, then run:
+
+```
+make check-links
+```
+
 ## Publishing changes
 
-Every change should be reviewed in a pull request, no matter how minor, and we've enabled [branch protection][] to enforce this.
+Make sure to make changes in a branch. Every change should be reviewed in a pull request, no matter how minor, and we've enabled
+[branch protection][] to enforce this.
 
 Once the pull request is merged, the deploy Github action workflow runs the build and pushes the static site to GOV.UK PaaS.
 
@@ -105,8 +108,7 @@ cdn-route service, we simply use the default `.london.cloudapps.digital` domain.
 
 ## Licence
 
-The documentation is [© Crown copyright][copyright] and available under the terms
-of the [Open Government 3.0][ogl] licence.
+The documentation is [© Crown copyright][copyright] and available under the terms of the [Open Government 3.0][ogl] licence.
 
 [rvm]: https://www.ruby-lang.org/en/documentation/installation/#managers
 [bundler]: http://bundler.io/

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: https://dfe-digital.github.io/technical-guidance
+host: https://technical-guidance.education.gov.uk
 
 # Header-related options
 show_govuk_logo: false
@@ -21,15 +21,15 @@ enable_search: true
 ga_tracking_id:
 
 # Enable multipage navigation in the sidebar
-multipage_nav: false
+multipage_nav: true
 
 # Enable collapsible navigation in the sidebar
-collapsible_nav: false
+collapsible_nav: true
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
 # headings.
-max_toc_heading_level: 3
+max_toc_heading_level: 1
 
 # Prevent robots from indexing (e.g. whilst in development)
 prevent_indexing: true
@@ -39,12 +39,3 @@ github_repo: DFE-Digital/technical-guidance
 github_branch: master
 
 redirects:
-  /principles/coding-principles: /documentation/principles/coding-principles.html
-  /principles/frontend-development-principles: /documentation/principles/frontend-development-principles.html
-  /standards/licencing-software-or-code: /documentation/standards/licencing-software-or-code.html
-  /standards/naming-things: /documentation/standards/naming-things.html
-  /standards/storing-source-code: /documentation/standards/storing-source-code.html
-  /standards/using-3rd-party-open-source-products: /documentation/standards/using-3rd-party-open-source-products.html
-  /guides/api-guidance: /documentation/guides/api-guidance.html
-  /guides/default-technology-stack: /documentation/guides/default-technology-stack.html
-  /guides/govuk-paas: /documentation/guides/govuk-paas.html

--- a/source/accessibility.html.md.erb
+++ b/source/accessibility.html.md.erb
@@ -9,7 +9,7 @@ hide_in_navigation: true
 
 ## Accessibility statement for the DfE Technical Guidance
 
-This accessibility statement applies to the DfE Technical Guidance at [https://dfe-digital.github.io/technical-guidance/](https://dfe-digital.github.io/technical-guidance/).
+This accessibility statement applies to the DfE Technical Guidance at [technical-guidance.education.gov.uk](https://technical-guidance.education.gov.uk/).
 
 This website is run by the architecture and developer communities at the Department for Education (DfE). We want as many people as possible to be able to use this website. For example, that means you should be able to:
 

--- a/source/documentation/guides/govuk-paas-customer-journey.html.md.erb
+++ b/source/documentation/guides/govuk-paas-customer-journey.html.md.erb
@@ -1,9 +1,0 @@
----
-title: Gov UK PaaS Customer Journey Map
-last_reviewed_on: 2021-04-16
-review_in: 2 months
----
-
-# <%= current_page.data.title %>
-
-<%= link_to image_tag('cust-journey-map.png'), '/images/cust-journey-map.png' %>

--- a/source/guides/adding-new-guidance/index.html.md.erb
+++ b/source/guides/adding-new-guidance/index.html.md.erb
@@ -1,0 +1,48 @@
+---
+title: Adding a new guidance
+weight: 10
+last_reviewed_on: 2020-07-01
+review_in: 1 year
+---
+
+# <%= current_page.data.title %>
+
+In the [DfE Digital technology guidance repository](https://github.com/DFE-Digital/technology-guidance), in the `source` directory, create a
+subdirectory representing the name of the guidance.
+
+For example: `source/guides/govuk-paas`.
+
+Inside the new directory, create an `index.html.md.erb` file following this pattern:
+
+```markdown
+---
+title: The Title of Your Page
+last_reviewed_on: 2020-08-05
+review_in: 3 months
+---
+
+# <%%= current_page.data.title %>
+
+Introduction of a couple of paragraphs to explain why the thing you're
+writing a standard about is important.
+
+## User needs
+
+Why do we do this thing? Who is it helping?
+
+## Principles
+
+What broad approaches do we follow when we do this thing?
+
+## Tools
+
+What specific bits of software (commercial or open source) do
+we use to help us do this thing?
+```
+
+Then make a pull request and inform maintainers in the `#architecture` Slack channel.
+
+Secondary pages related to a guidance may be created in the same directory as `<title>.html.md.erb`. To hide them from the sidebar navigation, add
+field `hide_in_navigation: true` to the page header.
+
+The guidance must be reviewed and updated before the expiration date.

--- a/source/guides/api-guidance/index.html.md.erb
+++ b/source/guides/api-guidance/index.html.md.erb
@@ -2,13 +2,15 @@
 title: "API Guidance: Developing a DfE API"
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/guides/api-guidance.html
 ---
 
 # <%= current_page.data.title %>
 
 APIs are an increasingly important part of DFE services. We are supporting an API first approach to help make our services highly operable and automated. API's, however, should start with a need or a problem to solve. They can be used in many different ways. They can be used to integrate systems and services, collect or share data, consume and publish events as well as consume other APIs.
 
-[Target audience](#who-is-the-target-audience-of-this-guidance?)
+[Target audience](#who-is-the-target-audience-of-this-guidance)
 
 [User needs and APIs](#user-needs)
 
@@ -28,7 +30,7 @@ APIs are an increasingly important part of DFE services. We are supporting an AP
 
 [Understand your data](#understand-your-data)
 
-[Return Codes](#return-codes-(http))
+[Return Codes](#return-codes-http)
 
 [Testing](#testing)
 

--- a/source/guides/default-technology-stack/index.html.md.erb
+++ b/source/guides/default-technology-stack/index.html.md.erb
@@ -2,6 +2,8 @@
 title: The DfE Digital Technology Stack
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/guides/default-technology-stack.html
 ---
 
 # <%= current_page.data.title %>
@@ -48,8 +50,8 @@ For more information about CIP and the onboarding process of services and users 
 
 <CloudPlatform.ENGINEERING@education.gov.uk> or [Slack](https://ukgovernmentdfe.slack.com/app_redirect?channel=C7L4D0LM9)
 
-*   [CIP Documentation Site](http://docs.platform.education.gov.uk)
-*   [DfE Enterprise Architecture](https://dfe-digital.github.io/enterprise-architecture/common-components/#1-cloud-infrastructure-platform)
+*   [CIP Documentation Site](http://docs.platform.education.gov.uk) (Azure CIP account required)
+*   [DfE Enterprise Architecture](https://dfe-digital.github.io/architecture/common-components/#how-do-we-use-components)
 
 Community support for Azure use in general can also be gained from the community in the [#cloud-platform Slack channel](https://ukgovernmentdfe.slack.com/app_redirect?channel=C7L4D0LM9).
 
@@ -57,7 +59,7 @@ Community support for Azure use in general can also be gained from the community
 
 We are currently exploring usage of [GOV.UK Platform as a Service](https://www.cloud.service.gov.uk/) as a secondary offering for applications requiring less customisation than provided by a full infrastructure-as-a-service platform such as Azure. It is suitable for less complex web services that follow typical GOV.UK patterns.
 
-For more details please refer to the [GOV.UK Platform as a Service](/documentation/guides/govuk-paas.html)
+For more details please refer to the [GOV.UK Platform as a Service](/guides/govuk-paas/)
 
 ### Infrastructure as code
 

--- a/source/guides/govuk-paas/govuk-paas-customer-journey.html.md.erb
+++ b/source/guides/govuk-paas/govuk-paas-customer-journey.html.md.erb
@@ -1,0 +1,10 @@
+---
+title: Gov UK PaaS Customer Journey Map
+last_reviewed_on: 2021-04-16
+review_in: 2 months
+hide_in_navigation: true
+---
+
+# <%= current_page.data.title %>
+
+<%= link_to image_tag('cust-journey-map.png', alt: 'Gov UK PaaS Customer Journey Map'), '/images/cust-journey-map.png' %>

--- a/source/guides/govuk-paas/govuk-paas-suitability.html.md.erb
+++ b/source/guides/govuk-paas/govuk-paas-suitability.html.md.erb
@@ -2,6 +2,7 @@
 title: PaaS Suitability Matrix vs Azure CIP
 last_reviewed_on: 2021-04-14
 review_in: 2 months
+hide_in_navigation: true
 ---
 
 # <%= current_page.data.title %>

--- a/source/guides/govuk-paas/index.html.md.erb
+++ b/source/guides/govuk-paas/index.html.md.erb
@@ -2,6 +2,8 @@
 title: GOV.UK Platform as a Service
 last_reviewed_on: 2021-04-28
 review_in: 3 months
+old_paths:
+- /documentation/guides/govuk-paas.html
 ---
 
 # <%= current_page.data.title %>
@@ -13,11 +15,11 @@ and available for government departments to deploy applications and backend serv
 Many DfE production applications run on GOV.UK PaaS like [Teaching vacancies](https://teaching-vacancies.service.gov.uk/),
 [Get into teaching](https://getintoteaching.education.gov.uk/) or [Get help with tech](https://get-help-with-tech.education.gov.uk/).
 
-You can request access to a sandbox space to explore GOV.UK PaaS for free. See [Onboarding](#onboarding).
+You can request access to a sandbox space to explore GOV.UK PaaS for free. See [Exploring GOV.UK PaaS](#exploring-gov-uk-paas).
 
 ## Suitability
 
-[Azure CIP](/documentation/guides/default-technology-stack.html#azure) is the traditional platform for hosting services in DfE. When does it make sense to use GOV.UK PaaS?
+[Azure CIP](/guides/default-technology-stack/#azure) is the traditional platform for hosting services in DfE. When does it make sense to use GOV.UK PaaS?
 
 ### Standard web applications
 
@@ -86,12 +88,12 @@ approach as specified in the Technology Code of Practice.
 ### Suitability Matrix
 
 To review the comparison of features and capabilities of both Azure platforms and Gov UK PaaS, see the
-[Suitability Matrix](/documentation/guides/govuk-paas-suitability.html).
+[Suitability Matrix](/guides/govuk-paas/govuk-paas-suitability.html).
 
 ### Customer Journey Map
 
 To review the Customer Journey Map which highlights the high-level key stages of discovery, review, approval and deployment etc, see the
-[customer journey map](/documentation/guides/govuk-paas-customer-journey.html).
+[customer journey map](/guides/govuk-paas/govuk-paas-customer-journey.html).
 
 ## Links
 * [Home page](https://www.cloud.service.gov.uk/)
@@ -103,7 +105,7 @@ To review the Customer Journey Map which highlights the high-level key stages of
 To separate users, applications, services and ultimately costs, GOV.UK PaaS provides
 [organisations and spaces](https://docs.cloud.service.gov.uk/orgs_spaces_users.html#managing-organisations-spaces-and-users).
 
-<%= image_tag 'orgs_and_spaces.svg' %>
+<%= image_tag('orgs_and_spaces.svg', alt: 'Org and spaces in DfE') %>
 
 ### Organisations
 DfE manages a GOV.UK PaaS organisation called `dfe`.

--- a/source/guides/index.html.md.erb
+++ b/source/guides/index.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: Guides
+weight: 10
+---
+
+# <%= current_page.data.title %>
+
+See sidebar to navigate guides.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,5 +1,8 @@
 ---
 title: DfE Technical Guidance
+weight: 1
+last_reviewed_on: 2020-07-01
+review_in: 1 year
 ---
 
 # <%= current_page.data.title %>
@@ -14,65 +17,3 @@ which covers service design more broadly.
 
 It is inspired by the [GDS Way](https://gds-way.cloudapps.digital) and the
 [Ministry of Justice Technical Guidance](https://ministryofjustice.github.io/technical-guidance/#moj-technical-guidance).
-
-## Principles
-
-* [Coding Principles](documentation/principles/coding-principles.html)
-* [Frontend Development Principles](documentation/principles/frontend-development-principles.html)
-
-## Standards
-
-### Building software
-
-* [Licensing software or code](documentation/standards/licencing-software-or-code.html)
-* [Naming things](documentation/standards/naming-things.html)
-* [Storing source code](documentation/standards/storing-source-code.html)
-
-### General standards
-
-* [Using 3rd-party open source products](documentation/standards/using-3rd-party-open-source-products.html)
-
-## Guides
-
-### APIs
-
-* [API Guidance: Developing a DfE API](documentation/guides/api-guidance.html)
-
-### Development guides
-
-* [The DfE Digital Technology Stack](documentation/guides/default-technology-stack.html)
-* [GOV.UK Platform as a Service](documentation/guides/govuk-paas.html)
-
-## Adding new guidance
-
-Create a new Markdown file in the [DfE Digital technology guidance repo](https://github.com/DFE-Digital/technology-guidance) that follows this pattern, add a link to it
-from this page, and make a pull request:
-
-```markdown
----
-title: The Title of Your Page
-last_reviewed_on: 2020-08-05
-review_in: 3 months
----
-
-# <%%= current_page.data.title %>
-
-Introduction of a couple of paragraphs to explain why the thing you're
-writing a standard about is important.
-
-## User needs
-
-Why do we do this thing? Who is it helping?
-
-## Principles
-
-What broad approaches do we follow when we do this thing?
-
-## Tools
-
-What specific bits of software (commercial or open source) do
-we use to help us do this thing?
-```
-
-The service manual has some useful information on
-[learning about and writing user needs](https://www.gov.uk/service-manual/user-research/start-by-learning-user-needs).

--- a/source/principles/coding-principles/index.html.md.erb
+++ b/source/principles/coding-principles/index.html.md.erb
@@ -2,6 +2,8 @@
 title: Coding Principles
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/principles/coding-principles.html
 ---
 
 # <%= current_page.data.title %>
@@ -56,8 +58,7 @@ Names convey meaning - well-named functions & variables can remove the need for 
 Avoid meaningless names like ‘obj’ / ‘result’ / ‘foo’.
 Use single-letter variables only where the letter represents a well-known mathematical property (e.g. e = mc^2), or where their meaning is otherwise clear.
 
-
-See [Naming things]({{ 'standards/naming-things' | relative_url  }})
+See [Naming things](/standards/naming-things/)
 
 ### 8. Composition over inheritance
 It’s tempting to build an inheritance tree of objects extending others and redefining methods where needed - but that often just creates tech debt for the future. Choose ‘has-a’ relationships over ‘is-a’ - e.g. a Car has-a Motor, rather than Car is-a MotorVehicle

--- a/source/principles/frontend-development-principles/index.html.md.erb
+++ b/source/principles/frontend-development-principles/index.html.md.erb
@@ -2,6 +2,8 @@
 title: Frontend Development Principles
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/principles/frontend-development-principles.html
 ---
 
 # <%= current_page.data.title %>
@@ -11,7 +13,7 @@ encouraged to follow when implementing a service’s frontend. These principles
 aren’t mandatory, but you should be able to provide a good argument if you
 choose to depart from them.
 
-These principles are in addition to the [Development Principles]({{ '/standards/development-principles' | relative_url }})
+These principles are in addition to the [Development Principles](/principles/coding-principles/)
 
 ## 1. Follow Government Service Design Manual
 

--- a/source/principles/index.html.md.erb
+++ b/source/principles/index.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: Principles
+weight: 20
+---
+
+# <%= current_page.data.title %>
+
+See sidebar to navigate principles.

--- a/source/standards/index.html.md.erb
+++ b/source/standards/index.html.md.erb
@@ -1,0 +1,8 @@
+---
+title: Standards
+weight: 30
+---
+
+# <%= current_page.data.title %>
+
+See sidebar to navigate standards.

--- a/source/standards/licencing-software-or-code/index.html.md.erb
+++ b/source/standards/licencing-software-or-code/index.html.md.erb
@@ -2,6 +2,8 @@
 title: Licensing software or code
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/standards/licencing-software-or-code.html
 ---
 
 # <%= current_page.data.title %>
@@ -44,7 +46,7 @@ shown as a period from first to most recent update (e.g. 2015-2017).
 
 ### Example
 
-`manage-courses-frontend` has a good [example of our licence](https://github.com/DFE-Digital/manage-courses-frontend/blob/master/LICENSE).
+`publish-teacher-training` has a good [example of our licence](https://github.com/DFE-Digital/publish-teacher-training/blob/master/LICENSE).
 
 ## Reusing or incorporating others' work
 
@@ -58,5 +60,5 @@ There's a good [guide to proper copyright and licence
 attribution](https://make.wordpress.org/themes/2014/07/08/proper-copyrightlicense-attribution-for-themes/)
 from the WordPress Theme Review Team.
 
-[This repository's licence file](https://github.com/ministryofjustice/technical-guidance/blob/master/LICENCE)
+[This repository's licence file](https://github.com/ministryofjustice/technical-guidance/blob/main/LICENSE)
 is a good example of how to attribute incorporated works' licences.

--- a/source/standards/naming-things/index.html.md.erb
+++ b/source/standards/naming-things/index.html.md.erb
@@ -2,6 +2,8 @@
 title: Naming things
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/standards/naming-things.html
 ---
 
 # <%= current_page.data.title %>

--- a/source/standards/storing-source-code/index.html.md.erb
+++ b/source/standards/storing-source-code/index.html.md.erb
@@ -2,6 +2,8 @@
 title: Storing source code
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/standards/storing-source-code.html
 ---
 
 # <%= current_page.data.title %>
@@ -30,8 +32,8 @@ Ask your delivery manager to request you being added to the Github organisation.
 
 Another Github organisation account heavilly used by the DfE but not the default for DfE-Digital is ['SkillsFundingAgency'](https://github.com/SkillsFundingAgency/).
 
-Repositories should be [clearly named]({{ '/standards/naming-things' | relative_url }}),
-and have an [appropriate licence]({{ '/standards/licencing-software-or-code' | relative_url }})
+Repositories should be [clearly named](/standards/naming-things/),
+and have an [appropriate licence](/standards/licencing-software-or-code)
 and enough documentation that someone new can get started with the
 project.
 

--- a/source/standards/using-3rd-party-open-source-products/index.html.md.erb
+++ b/source/standards/using-3rd-party-open-source-products/index.html.md.erb
@@ -2,11 +2,11 @@
 title: Using 3rd-party open source products
 last_reviewed_on: 2020-12-21
 review_in: 3 months
+old_paths:
+- /documentation/standards/using-3rd-party-open-source-products.html
 ---
 
 # <%= current_page.data.title %>
-
-# Using 3rd-party open source products
 
 In order to make effective commercial decisions, it is important to recognise
 the characteristics of open source software that we find desirable. These


### PR DESCRIPTION
Use standard implementation as described in [tech docs template](https://tdt-documentation.london.cloudapps.digital/) to make it easier to navigate.

See review app below.