### PR TITLE
Propose changes to the tech stack guidance to reflect current developer market

### DIFF
--- a/source/guides/default-technology-stack/index.html.md.erb
+++ b/source/guides/default-technology-stack/index.html.md.erb
@@ -18,9 +18,7 @@ The department supports two core tech stacks: Ruby on Rails and .NET. These stac
 
 ### The Ruby Stack
 
-Ruby and Rails align to government guidance on using open source software. We recommend using the latest stable version of Ruby on Rails (5.2 at time of writing) on the latest stable version of Ruby (3.0.3 at the time of writing).
-
-We recommend that teams look at the [boilerplate project](https://github.com/DFE-Digital/govuk-rails-boilerplate) when starting their projects.
+Ruby and Rails align to government guidance on using open source software. We recommend that teams look at the [boilerplate project](https://github.com/DFE-Digital/govuk-rails-boilerplate) when starting their projects.
 
 ### The .NET Core stack
 

--- a/source/guides/default-technology-stack/index.html.md.erb
+++ b/source/guides/default-technology-stack/index.html.md.erb
@@ -10,24 +10,15 @@ old_paths:
 
 At DfE Digital, we believe that boring decisions are good decisions.  We therefore provide some default options for technology choices that are well supported within the community and well tested.
 
-These recommendations are purely that, recommendations, rather than standards that you must meet.  There are often reasons from deviating from these recommendations, but as a team you should be prepared to justify why you made these decisions, and to trace that back to a user need the drives the decision.
+These recommendations are purely that: recommendations. They are not standards that you must meet. There are often reasons for deviating from these recommendations, but as a team you should be prepared to justify why you made these decisions, and to trace that back to a user need that drives the decision.
 
 ## Application Stacks
 
-The department supports two core tech stacks: Ruby and .NET.
+The department supports two core tech stacks: Ruby on Rails and .NET. These stacks are equally well-supported in the department, and teams are encouraged to select the stack that works best for them. Speak to the Head of Software Engineering Profession for guidance.
 
 ### The Ruby Stack
 
-DfE Digital has a strong preference for a Ruby on Rails stack for development.  We recommend using the latest stable version of Ruby on Rails (5.2 at time of writing) on the latest stable version of Ruby (3.0.3 at the time of writing).
-
-Ruby was selected as the programming language of choice for digital delivery for a number of reasons:
-
-* Ease of hiring developers from user centred backgrounds with experience of working in multi-disciplinary teams engaged in agile/iterative delivery. We can tap into a large pool of Ruby developers already experienced with government digital due to the wide adoption of Ruby and the Ruby on Rails framework within GDS, MOJ Digital and other departments
-* Generally a large pool of Ruby developers available in the two DfE Digital key locations of London and Manchester. There are active and vibrant Ruby communities in both locations ([NWRUG](https://nwrug.org/) and [LRUG](http://lrug.org/))
-* The number of Ruby focused digital agencies and managed services setting up in Manchester and other areas of the country to meet the increased need for digital delivery and related specialists
-* The reuse potential of the hundreds of [open source repositories from GDS](https://github.com/alphagov) and [other government digital departments](https://github.com/ministryofjustice), as well as the extensive ecosystem of GOV.UK centred Ruby gems
-* [The very large ecosystem of Ruby gems](https://rubygems.org/) allows for rapid prototyping and building with access to a wide range of mature, common functionality
-* Consolidating on one language and framework as part of the digital strategy ensures consistency, reducing risks around long-term sustainability of services easier and streamlines permanent capability building, while also aligning with wider government digital
+Ruby and Rails align to government guidance on using open source software. We recommend using the latest stable version of Ruby on Rails (5.2 at time of writing) on the latest stable version of Ruby (3.0.3 at the time of writing).
 
 We recommend that teams look at the [boilerplate project](https://github.com/DFE-Digital/govuk-rails-boilerplate) when starting their projects.
 

--- a/source/guides/default-technology-stack/index.html.md.erb
+++ b/source/guides/default-technology-stack/index.html.md.erb
@@ -18,7 +18,7 @@ The department supports two core tech stacks: Ruby and .NET.
 
 ### The Ruby Stack
 
-DfE Digital has a strong preference for a Ruby on Rails stack for development.  We recommend using the latest stable version of Ruby on Rails (5.2 at time of writing) on the latest stable version of Ruby (2.5 at the time of writing).
+DfE Digital has a strong preference for a Ruby on Rails stack for development.  We recommend using the latest stable version of Ruby on Rails (5.2 at time of writing) on the latest stable version of Ruby (3.0.3 at the time of writing).
 
 Ruby was selected as the programming language of choice for digital delivery for a number of reasons:
 


### PR DESCRIPTION
The departments strategy is to build capability outside of London, closer to the communities we serve. As it stands, we are struggling to recruit Ruby developers outside of London. We will be building this capability through early talent schemes, including apprenticeships, but in the short term we should recognise that C# has an equally valuable part to play in the way that we deliver services. 