### PR TITLE
Update guidance to point to new keyvault-yaml-secret action

### DIFF
--- a/source/infrastructure/security/managing-secrets/index.html.md.erb
+++ b/source/infrastructure/security/managing-secrets/index.html.md.erb
@@ -102,7 +102,7 @@ az keyvault secret download  --vault-name sXXXd01-kv --name TTA-KEYS --file loca
 _Make sure to delete the local file after use._
 
 ### Read using Github actions
-Use the [keyvault-yaml-secret action](https://github.com/DFE-Digital/github-actions/tree/master/keyvault-yaml-secret) to retrieve a secret from the yaml file.
+Use the [keyvault-yaml-secret action](https://github.com/DFE-Digital/keyvault-yaml-secret) to retrieve a secret from the yaml file.
 
 ### Read using terraform
 Use the [yamldecode](https://www.terraform.io/docs/language/functions/yamldecode.html) function to parse the yaml file and access individual values:


### PR DESCRIPTION
We have a new version of the secrets action that bumps up the security a bit and also moves things over to TypeScript. This commit updates the link that points to the action repository.