### PR TITLE
[493] Remove references to MOJ

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -29,4 +29,7 @@ License.
 The DfE Technical Guidance site is based on [GDS's The GDS Way](https://github.com/alphagov/gds-way),
 Copyright (c) 2017 Crown Copyright (Government Digital Service).
 GDS's The GDS Way is distributed under the terms of the [Open
-Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)
+Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+
+It is also based on the [MoJ's technical guidance](https://github.com/ministryofjustice/technical-guidance/),
+distributed under the terms of the MIT License.

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,9 +9,7 @@ This site documents the technical standards and guidance that we expect teams wo
 within the [Department for Education](https://www.gov.uk/government/organisations/department-for-education)
 to follow when building digital services.
 
-It complements the [Service Manual](https://www.gov.uk/service-manual) and its
-[Technology section](https://www.gov.uk/service-manual/technology),
-which covers service design more broadly.
+It complements the [DfE Service manual](https://service-manual.education.gov.uk/), [DfE Architecture](https://dfe-digital.github.io/architecture/#dfe-architecture)
+and the [GOV.UK Service Manual](https://www.gov.uk/service-manual).
 
-It is inspired by the [GDS Way](https://gds-way.cloudapps.digital) and the
-[Ministry of Justice Technical Guidance](https://ministryofjustice.github.io/technical-guidance/#moj-technical-guidance).
+Useful tools and patterns are presented to help with code reuse, security and consistency.

--- a/source/principles/frontend-development-principles/index.html.md.erb
+++ b/source/principles/frontend-development-principles/index.html.md.erb
@@ -9,7 +9,7 @@ old_paths:
 
 # <%= current_page.data.title %>
 
-This document lists some principles that developers at MOJ are strongly
+This document lists some principles that developers at DfE are strongly
 encouraged to follow when implementing a service’s frontend. These principles
 aren’t mandatory, but you should be able to provide a good argument if you
 choose to depart from them.
@@ -21,7 +21,7 @@ These principles are in addition to the [Development Principles](/principles/cod
 The most important set of recommendations you really should follow is from the [Government Service Design Manual](https://www.gov.uk/service-manual), not only because the service
 you’re designing will be assessed against it 3 times before going Live, but also
 because it covers the broad principles and is generally right. What follows are
-MOJ-specific recommendations.
+DfE-specific recommendations.
 
 ## 2. Make your service accessible
 Your site must be compliant with level AA of the [Web Content Accessibility Guidelines 2.0](https://www.w3.org/WAI/intro/wcag). You should also try assistive

--- a/source/standards/licencing-software-or-code/index.html.md.erb
+++ b/source/standards/licencing-software-or-code/index.html.md.erb
@@ -1,7 +1,7 @@
 ---
 title: Licensing software or code
-last_reviewed_on: 2020-12-21
-review_in: 3 months
+last_reviewed_on: 2022-01-12
+review_in: 6 months
 old_paths:
 - /documentation/standards/licencing-software-or-code.html
 ---
@@ -46,7 +46,7 @@ shown as a period from first to most recent update (e.g. 2015-2017).
 
 ### Example
 
-`publish-teacher-training` has a good [example of our licence](https://github.com/DFE-Digital/publish-teacher-training/blob/master/LICENSE).
+`Apply for teacher training` has a good [example of our licence](https://github.com/DFE-Digital/apply-for-teacher-training/blob/main/LICENCE).
 
 ## Reusing or incorporating others' work
 
@@ -60,5 +60,5 @@ There's a good [guide to proper copyright and licence
 attribution](https://make.wordpress.org/themes/2014/07/08/proper-copyrightlicense-attribution-for-themes/)
 from the WordPress Theme Review Team.
 
-[This repository's licence file](https://github.com/ministryofjustice/technical-guidance/blob/main/LICENSE)
+[This repository's licence file](https://github.com/DFE-Digital/technical-guidance/blob/master/LICENCE)
 is a good example of how to attribute incorporated works' licences.


### PR DESCRIPTION
## What
This site was initially copied from MOJ and it still had a few references to it by mistake.
Some examples are still MOJ. They are valid but we could improve with DFE examples instead. This will be done in a separate PR.

The home page is improved with links to other DfE tech reference sites.