### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# This file details the owners of this repo
+# This team is automatically requested to review new PRs
+# More info: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# There is also a flag in the GitHub interface to only allow approvals by this team
+* @DFE-Digital/dfe-lead-devs


### PR DESCRIPTION
This change would automatically ask for a review from the dfe-lead-devs team when a PR is raised. I think this will help us control the flow of information into the repo and make sure our standards, principles, and guidance are technically sound. It would also allow us to give write access to everyone in dfe-digital, thereby making it much easier to raise a PR and start contributing to the repo.

It should be combined with the GitHub interface flag to ensure that PRs can only be merged when they've been approved by someone in this team