### PR TITLE
Edit example link text for consistency

### DIFF
--- a/source/guides/adding-new-guidance/index.html.md.erb
+++ b/source/guides/adding-new-guidance/index.html.md.erb
@@ -56,7 +56,7 @@ To avoid repeating content and simplify maintaining, common data can be centrali
 Can be referred to as:
 
 ```
-[Digital tools](<%%= data.site.digital_tools %>)
+[Digital tools support](<%%= data.site.digital_tools %>)
 ```
 
 Which will be rendered as: [Digital tools support](<%= data.site.digital_tools %>)


### PR DESCRIPTION
The code block entry (line 59) and the example below it (line 62) have different link text. This PR remedies this.

Note that the edit could have gone either way, but I opted for `Digital tools support` to remove any potential ambiguity or correlation with the variable name `digital_tools`.