### PR TITLE
Update link and description of start pages

### DIFF
--- a/source/infrastructure/hosting/dns/index.html.md.erb
+++ b/source/infrastructure/hosting/dns/index.html.md.erb
@@ -84,4 +84,5 @@ ns-485.awsdns-60.com.
 * Create the required subdomains <subdomain>.<service>.service.gov.uk. Example: [www.apply-for-teacher-training.service.gov.uk](http://www.apply-for-teacher-training.service.gov.uk/)
 
 ## Start page
-Each service must have a start page on [gov.uk](http://gov.uk/) website, which briefly describes the service and let the user navigate to the service under the mandatory service.gov.uk domain. This is documented [here](https://design-system.service.gov.uk/patterns/start-pages/).
+
+Each service must have a start page on [GOV.UK](http://gov.uk/) website, which briefly describes the service and let the user navigate to the service under the mandatory service.gov.uk domain. The GOV.UK Design System has documentation on the [‘start using a service’ pattern](https://design-system.service.gov.uk/patterns/start-pages/) which describes the different options.

--- a/source/infrastructure/hosting/dns/index.html.md.erb
+++ b/source/infrastructure/hosting/dns/index.html.md.erb
@@ -85,4 +85,4 @@ ns-485.awsdns-60.com.
 
 ## Start page
 
-Each service must have a start page on [GOV.UK](http://gov.uk/) website, which briefly describes the service and let the user navigate to the service under the mandatory service.gov.uk domain. The GOV.UK Design System has documentation on the [‘start using a service’ pattern](https://design-system.service.gov.uk/patterns/start-pages/) which describes the different options.
+Each service must have a start page on [GOV.UK](https://www.gov.uk) website, which briefly describes the service and let the user navigate to the service under the mandatory service.gov.uk domain. The GOV.UK Design System has documentation on the [‘start using a service’ pattern](https://design-system.service.gov.uk/patterns/start-pages/) which describes the different options.


### PR DESCRIPTION
The link to the documentation for start pages is out of date, as [https://design-system.service.gov.uk/patterns/start-pages/](https://design-system.service.gov.uk/patterns/start-pages/) has moved to [https://design-system.service.gov.uk/patterns/start-using-a-service/](https://design-system.service.gov.uk/patterns/start-using-a-service/) with more expanded guidance.