### PR TITLE
Updated index to remove Service Manual and add new manuals

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -9,7 +9,7 @@ This site documents the technical standards and guidance that we expect teams wo
 within the [Department for Education](https://www.gov.uk/government/organisations/department-for-education)
 to follow when building digital services.
 
-It complements the [DfE Service manual](https://service-manual.education.gov.uk/), [DfE Architecture](https://dfe-digital.github.io/architecture/#dfe-architecture)
+It complements the [guidance for How to apply the Service Standard in DfE](https://apply-the-service-standard.education.gov.uk/), [Design Manual](https://design.education.gov.uk/), [DfE Architecture](https://dfe-digital.github.io/architecture/#dfe-architecture)
 and the [GOV.UK Service Manual](https://www.gov.uk/service-manual).
 
 Useful tools and patterns are presented to help with code reuse, security and consistency.


### PR DESCRIPTION
DfE Service manual has been decomissioned, we now have the Apply the Service Standard in DfE and Design Manuals. 