### PR TITLE
Update guidance on default tech stack

### DIFF
--- a/source/guides/default-technology-stack/index.html.md.erb
+++ b/source/guides/default-technology-stack/index.html.md.erb
@@ -15,7 +15,7 @@ These recommendations are purely that: recommendations. They are not standards t
 
 ## Application Stacks
 
-The department supports two core tech stacks: Ruby on Rails and .NET. These stacks are equally well-supported in the department, and teams are encouraged to select the stack that works best for them. Speak to the Head of Software Engineering Profession for guidance.
+The department supports two core tech stacks: .NET and Ruby on Rails. Currently, C#.NET is our preferred tech stack and Ruby is used by exception. Speak to the Head of Software Engineering Profession for guidance on how to choose the right one for your team.
 
 ### The Ruby Stack
 


### PR DESCRIPTION
I've updated the tech stack guidance to reflect the DfEs current location and recruitment strategy.