### PR TITLE
Change azure hosting guidance copy

### DIFF
--- a/source/infrastructure/hosting/azure-cip/index.html.md.erb
+++ b/source/infrastructure/hosting/azure-cip/index.html.md.erb
@@ -22,7 +22,7 @@ Portal: [https://portal.azure.com/](https://portal.azure.com/)
 ## Onboarding users
 Use this [service portal form](https://dfe.service-now.com.mcas.ms/serviceportal/?id=sc_cat_item&sys_id=51b0b9c5db1ff7809402e1aa4b96197d&referrer=recent_items) to create the onboarding request:
 
-1. From _Request type_ dropdown, select: _Access to CIP Azure Portal/DevOps_
+1. From _Request type_ dropdown, select: _Azure Portal and DevOps User Account Request_
 1. From _Add/Change/Remove_ dropdown, select: _Add_
 1. Enter new users' email addresses
 
@@ -30,9 +30,9 @@ If access to the service portal is not possible, ask the helpdesk (See [Support]
 
 Ask in #cloud-platform on Slack if more help is required.
 
-The new user will receive an invitation by email. Then the service managers can add them to the service Azure Active Directory groups of the subscriptions: Managers and Delivery team.
+The new user will receive an invitation by email. Then the service administrators can add them to the service Azure Active Directory groups of the subscriptions: Managers and Delivery team.
 
-To access Azure DevOps, the new user must access the [Azure DevOps CIP instance](https://dev.azure.com/dfe-ssp/). This will register them in the system then the service owner can add them to the project.
+To access Azure DevOps, the new user must access the [Azure DevOps CIP instance](https://dev.azure.com/dfe-ssp/). This will register them in the system then the service administrator can add them to the project.
 
 ## Privileged Identity Management (PIM) Requests
 


### PR DESCRIPTION
Noticed the suggested request type dropdown option was not correct and after a conversation with @saliceti agreed that both 'service managers' and 'service owner' were a bit ambiguous, so replaced them with 'system administrator(s)'. 

Have changed some of the copy accordingly.