### PR TITLE
Add SNYK scan to build image

### DIFF
--- a/.github/workflows/deploy_aks.yml
+++ b/.github/workflows/deploy_aks.yml
@@ -36,6 +36,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         context: .
+        snyk-token: ${{ secrets.SNYK_TOKEN }}
 
     - name: Prepare matrix environments review
       id: matrix-env-review

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM nginxinc/nginx-unprivileged:1.26.1
+FROM nginxinc/nginx-unprivileged:1.27.3-alpine3.20
 
 COPY ./build/ /usr/share/nginx/html


### PR DESCRIPTION
### Context

We should scan the build image using SNYK

### Changes proposed in this pull request

Add SNYK key so the build action runs the scan.
Update the base image

### Guidance to review

Check 
- build log: https://github.com/DFE-Digital/technical-guidance/actions/runs/12771065072
- review app

### Link to Trello card

https://trello.com/c/9tIfEgW1/2166-scan-docker-image-in-all-repositories
