### PR TITLE
Pin 3rd party github actions

### DIFF
--- a/.github/workflows/build_nocache.yml
+++ b/.github/workflows/build_nocache.yml
@@ -34,7 +34,7 @@ jobs:
           snyk-token: ${{ secrets.SNYK_TOKEN }}
 
       - name: Notify slack on failure
-        uses: rtCamp/action-slack-notify@master
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # Pinned at 2.3.3
         if: ${{ failure() }}
         with:
           SLACK_USERNAME: CI Deployment

--- a/.github/workflows/deploy_aks.yml
+++ b/.github/workflows/deploy_aks.yml
@@ -94,7 +94,7 @@ jobs:
 
           - name: Post comment to Pull Request ${{ github.event.number }}
             if: ${{ github.event_name == 'pull_request' }}
-            uses: marocchino/sticky-pull-request-comment@v2
+            uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # Pinned at v2.9.4
             with:
               header: aks
               message: Review app deployed to <${{ steps.get-app-url.outputs.url }}>


### PR DESCRIPTION
### Trello card

https://trello.com/c/8RwMeaL4/2682-pin-third-party-github-actions-mobilise

### Changes proposed in this pull request

- pin all 3rd party github actions at specific versions (for security)

### Guidance to review

see successful workflows run by this PR