### PR TITLE
Remove referral to slack

### DIFF
--- a/source/infrastructure/hosting/azure-cip/index.html.md.erb
+++ b/source/infrastructure/hosting/azure-cip/index.html.md.erb
@@ -22,8 +22,6 @@ Use this [IT Help Centre form](https://dfe.service-now.com.mcas.ms/ithelpcentre/
 1. From _Add/Change/Remove_ dropdown, select: _Add_
 1. Enter new users' email addresses
 
-Ask in #cloud-platform on Slack if more help is required.
-
 The new user will receive an invitation by email. Then the service administrators can add them to the service Azure Active Directory groups of the subscriptions: Managers and Delivery team.
 
 To access Azure DevOps, the new user must access the [Azure DevOps CIP instance](https://dev.azure.com/dfe-ssp/). This will register them in the system then the service administrator can add them to the project.


### PR DESCRIPTION
Remove referral to slack channel, since this is no longer approved for use.

Happy to be corrected if there's a similar place in Teams where folks can go for support.